### PR TITLE
Fixed link to redirect to new CI skills page

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GitHub Actions makes it easier than ever to incorporate continuous delivery (CD)
 - **Who is this for**: Developers, DevOps engineers, full stack developers, cloud engineers.
 - **What you'll learn**: Continuous delivery, how to save and access build artifacts, package management, how to publish to GitHub Packages.
 - **What you'll build**: We will build a Docker image that runs a small game.
-- **Prerequisites**: We recommend you first complete the following courses: [Hello, GitHub Actions](https://github.com/skills/hello-github-actions) and [Continuous Integration](https://lab.github.com/skills/continuous-integration).
+- **Prerequisites**: We recommend you first complete the following courses: [Hello, GitHub Actions](https://github.com/skills/hello-github-actions) and [Continuous Integration](https://github.com/skills/continuous-integration).
 - **How long**: This course is five steps long and takes less than 30 minutes to complete.
 
 ## How to start this course


### PR DESCRIPTION
Changed link from Github Learning Lab to new GitHub Skills.

### Why:

Dead link to older Github Learning Lab to the newer Github Skills Continuous Integration Repository.

### What's being changed:

Link now redirects to Github Skills Continuous Integration repository.

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
