### PR TITLE
Missing read permissions to repo content

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ We'll start by creating the workflow file to publish a Docker image to GitHub Pa
          - main
    permissions:
      packages: write
+     contents: read
    jobs:
      publish:
        runs-on: ubuntu-latest


### PR DESCRIPTION
I added the `contents: read` permissions to the workflow file so that the managed identity can have access to the repo contents on the **checkout** action step. 

### Why:

The sample script fails on the first step (checkout) with a permission error without this line.

### What's being changed:

```
permissions:
  packages: write # This is required for requesting the JWT
  contents: read  # This is required for actions/checkout
```

### Check off the following:

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
