### PR TITLE
Adding "contents" to the sample publish workflow

### DIFF
--- a/.github/steps/1-create-the-workflow-file.md
+++ b/.github/steps/1-create-the-workflow-file.md
@@ -37,6 +37,7 @@ We'll start by creating the workflow file to publish a Docker image to GitHub Pa
          - main
    permissions:
      packages: write
+     contents: read
    jobs:
      publish:
        runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->
Unless `contents: read` is added, the current workflow will fail at checkout stage in a private repository with the following:
```
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +87a962e1f4c0a79b3fb369709f767043d61d87c6:refs/remotes/origin/main
  remote: Repository not found.
  Error: fatal: repository 'https://github.com/****/skills-publish-packages/' not found
  The process '/usr/bin/git' failed with exit code 128
```


### Changes
<!-- Describe the changes this pull request introduces. -->
added `contents: read` line to the workflow

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
