### PR TITLE
Update references from skills-dev to skills organization

### DIFF
--- a/.github/steps/x-review.md
+++ b/.github/steps/x-review.md
@@ -15,5 +15,5 @@ Here's a recap of your accomplishments:
 ### What's next?
 
 - Check out the other [GitHub Skills exercises](https://learn.github.com/skills).
-  - Take the [Test with Actions](https://github.com/skills-dev/test-with-actions) exercise to learn how to automate testing with GitHub Actions! Running automated tests before publishing packages is a good idea!
+  - Take the [Test with Actions](https://github.com/skills/test-with-actions) exercise to learn how to automate testing with GitHub Actions! Running automated tests before publishing packages is a good idea!
 - See GitHub Docs for more on [GitHub Packages](https://docs.github.com/en/packages) and [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).


### PR DESCRIPTION
## Summary

This PR updates all references from the `skills-dev` organization to the `skills` organization.

## Context

We have merged all repositories from the `skills-dev` organization into the main `skills` organization. This PR updates any links and references that still point to `skills-dev` to ensure they point to the correct organization.

## Changes

- Updated repository references from `skills-dev` to `skills`
- No functional changes, only URL/reference updates