### PR TITLE
fix: update raven-actions/actionlint version and lock actionlint version

### DIFF
--- a/.github/workflows/1-step.yml
+++ b/.github/workflows/1-step.yml
@@ -60,9 +60,11 @@ jobs:
       - name: Lint docker-publish.yml with actionlint
         id: actionlint-check
         continue-on-error: true
-        uses: raven-actions/actionlint@963d4779ef039e217e5d0e6fd73ce9ab7764e493 # v2.1.0
+        uses: raven-actions/actionlint@v2.1.1
         with:
           files: .github/workflows/docker-publish.yml
+          version: 1.7.10
+          fail-on-error: true
 
       - name: Check if workflow file exists
         id: check-file-exists

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -62,9 +62,11 @@ jobs:
       - name: Lint docker-publish.yml with actionlint
         id: actionlint-check
         continue-on-error: true
-        uses: raven-actions/actionlint@963d4779ef039e217e5d0e6fd73ce9ab7764e493 # v2.1.0
+        uses: raven-actions/actionlint@v2.1.1
         with:
           files: .github/workflows/docker-publish.yml
+          version: 1.7.10
+          fail-on-error: true
 
       - name: Check for setup-buildx-action
         id: check-buildx

--- a/.github/workflows/3-step.yml
+++ b/.github/workflows/3-step.yml
@@ -62,9 +62,11 @@ jobs:
       - name: Lint docker-publish.yml with actionlint
         id: actionlint-check
         continue-on-error: true
-        uses: raven-actions/actionlint@963d4779ef039e217e5d0e6fd73ce9ab7764e493 # v2.1.0
+        uses: raven-actions/actionlint@v2.1.1
         with:
           files: .github/workflows/docker-publish.yml
+          version: 1.7.10
+          fail-on-error: true
 
       - name: Check for metadata-action
         id: check-metadata


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

This pull request updates the `actionlint` GitHub Action configuration in three workflow files to use a newer version and enforces stricter linting on the `docker-publish.yml` workflow. The changes ensure that the latest features and bug fixes are used and that linting errors will now cause the step to fail.

**GitHub Actions maintenance:**

* Updated the `actionlint` action in `.github/workflows/1-step.yml`, `.github/workflows/2-step.yml`, and `.github/workflows/3-step.yml` to use the `v2.1.1` tag instead of a specific commit hash. [[1]](diffhunk://#diff-6c6f5ac6d7d4f149a1e9ed5091f17d9cb9561291ffc92165ad87ed13ad440c0eL63-R67) [[2]](diffhunk://#diff-19e83e79b520eae3dce9ab2230673b8eb4c551296d7cb4081a9cf52825d5ace6L65-R69) [[3]](diffhunk://#diff-94bad2f3b152c388b6c0a87ed5162854262af57bddafcc9667acc10fb5f877aaL65-R69)
* Added the `version: 1.7.10` and `fail-on-error: true` inputs to the `actionlint` steps in all three workflow files, ensuring a specific tool version is used and that failures are not ignored. [[1]](diffhunk://#diff-6c6f5ac6d7d4f149a1e9ed5091f17d9cb9561291ffc92165ad87ed13ad440c0eL63-R67) [[2]](diffhunk://#diff-19e83e79b520eae3dce9ab2230673b8eb4c551296d7cb4081a9cf52825d5ace6L65-R69) [[3]](diffhunk://#diff-94bad2f3b152c388b6c0a87ed5162854262af57bddafcc9667acc10fb5f877aaL65-R69)

### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Fixes: https://github.com/skills/publish-docker-images/issues/71
Fixes: https://github.com/skills/publish-docker-images/issues/72

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
