### PR TITLE
fix: typos

### DIFF
--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -17,7 +17,7 @@ GitHub Packages is a platform for hosting and managing packages, including conta
 - 🐘 Gradle
 - 🔷 NuGet
 
-GitHub Packages are associated with a GitHub account (User or Organization) namespace, not solely a repository. This is often beneficial because you may want to distribute a package and reuse a it across multiple repositories.
+GitHub Packages are associated with a GitHub account (user or organization) namespace, not solely a repository. This is often beneficial because you may want to distribute a package and reuse it across multiple repositories.
 
 In this exercise we will setup automation to publish 🐳 **[Docker](https://docs.docker.com/get-started/docker-overview/)** images to **[GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)** (`ghcr.io`). We will need to ensure the `packages` `permission` is set so the GitHub Actions built-in `GITHUB_TOKEN` secret can be used for authenticating to the registry.
 

--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -17,7 +17,7 @@ GitHub Packages is a platform for hosting and managing packages, including conta
 - 🐘 Gradle
 - 🔷 NuGet
 
-GitHub Packages are associated with a GitHub account (user or organization) namespace, not solely a repository. This is often beneficial because you may want to distribute a package and reuse it across multiple repositories.
+GitHub Packages is associated with a GitHub account (user or organization) namespace, not solely a repository. This is often beneficial because you may want to distribute a package and reuse it across multiple repositories.
 
 In this exercise we will setup automation to publish 🐳 **[Docker](https://docs.docker.com/get-started/docker-overview/)** images to **[GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)** (`ghcr.io`). We will need to ensure the `packages` `permission` is set so the GitHub Actions built-in `GITHUB_TOKEN` secret can be used for authenticating to the registry.
 

--- a/.github/steps/4-step.md
+++ b/.github/steps/4-step.md
@@ -111,10 +111,10 @@ You're done! As an optional step, you can explore the package settings for your 
 
    > 💡 **Tip:** This is particularly useful in an organization setting where multiple repositories may need access to the same package.
 
-1. (optional) Under **Danger Zone** you change the visibility or delete the package (all of its versions).
+1. (optional) Under **Danger Zone**, you can change the visibility or delete the package (including all of its versions).
 
    <img width="600" alt="Image showing danger zone section" src="https://github.com/user-attachments/assets/7928c7c0-def3-4d51-9a1d-42273ff68a36" />
 
-   > ❕ **Important:** Since packages are linked to your **account** (not the repository), deleting this repository **will not** delete the package. If you ever want to delete the package you must delete do it from this page.
+   > ❕ **Important:** Since packages are linked to your **account** (not the repository), deleting this repository **will not** delete the package. If you ever want to delete the package, you must do so from this page.
 
 </details>


### PR DESCRIPTION
### Summary

Improved the **wording** and **punctuation** and corrected **minor typos** in the exercise steps.

### Changes

- Fixed a typo in the explanation of package reuse in `.github/steps/1-step.md`.
- Improved the instructions for changing package visibility or deleting a package in `.github/steps/4-step.md`.

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide).